### PR TITLE
DEP: Sync requirements with info.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy>=1.9.0
-scipy>=0.11
+scipy>=0.14
 networkx>=1.9
 traits>=4.6
-python-dateutil>=1.5
+python-dateutil>=2.2
 nibabel>=2.1.0
 future>=0.16.0
 simplejson>=3.8.0

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,8 +1,8 @@
-numpy>=1.6.2
-scipy>=0.11
+numpy>=1.9.0
+scipy>=0.14
 networkx>=1.9
 traits>=4.6
-python-dateutil>=1.5
+python-dateutil>=2.2
 nibabel>=2.1.0
 future>=0.16.0
 simplejson>=3.8.0


### PR DESCRIPTION
Noticed these while checking the conda-forge recipe. Probably NBD, otherwise they would have been flagged before.